### PR TITLE
release v0.1.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@nextcloud/vue-dashboard",
-	"version": "0.1.7",
+	"version": "0.1.8",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@nextcloud/vue-dashboard",
-	"version": "0.1.7",
+	"version": "0.1.8",
 	"description": "Vue component for dashboard",
 	"keywords": [
 		"vuejs",


### PR DESCRIPTION
There's a problem with v0.1.7 on page load. Everything is fine with latest master when linking. I guess latest commits fixed the issue.