### PR TITLE
Split DashboardWidgetItem 'item' prop

### DIFF
--- a/src/DashboardWidget.vue
+++ b/src/DashboardWidget.vue
@@ -100,7 +100,7 @@ const itemMenu = {
 
 ```
 
-## Simplest example
+## Simplest example with custom item
 ```vue
 <template>
 	<DashboardWidget :items="items">
@@ -111,7 +111,7 @@ const itemMenu = {
 </template>
 
 <script>
-import DashboardWidget from '../components/DashboardWidget'
+import { DashboardWidget } from '@nextcloud/vue-dashboard'
 const myItems = [
 	{
 		title: 'first',
@@ -138,7 +138,7 @@ export default {
 </script>
 ```
 
-## Complete example
+## Complete example using DashboardWidgetItem
 ```vue
 <template>
 	<DashboardWidget :items="items"
@@ -146,8 +146,7 @@ export default {
 		:itemMenu="itemMenu"
 		@hide="onHide"
 		@markDone="onMarkDone"
-		:loading="state === 'loading'"
-		>
+		:loading="state === 'loading'">
 
 		<template v-slot:empty-content>
 			Nothing to display
@@ -156,7 +155,7 @@ export default {
 </template>
 
 <script>
-import DashboardWidget from '../components/DashboardWidget'
+import { DashboardWidget } from '@nextcloud/vue-dashboard'
 const myItems = [
 	{
 		id: '1',
@@ -237,14 +236,14 @@ export default {
 			<li v-for="item in displayedItems" :key="item.id">
 				<slot name="default" :item="item">
 					<DashboardWidgetItem
-						:item="item"
+						:target-url="item.targetUrl"
+						:avatar-url="item.avatarUrl"
+						:avatar-username="item.avatarUsername"
+						:overlay-icon-url="item.overlayIconUrl"
+						:main-text="item.mainText"
+						:sub-text="item.subText"
 						:item-menu="itemMenu"
-						v-on="handlers">
-						<!-- here we forward the popover slot to the item component >
-						<template v-slot:popover="{ item }">
-							<slot name="popover" :item="item" />
-						</template-->
-					</DashboardWidgetItem>
+						v-on="handlers" />
 				</slot>
 			</li>
 		</ul>
@@ -310,11 +309,6 @@ export default {
 			type: Object,
 			default: () => { return {} },
 		},
-		/* popoverEnabled: {
-			type: Boolean,
-			default: false,
-		}, */
-
 		showItemsAndEmptyContent: {
 			type: Boolean,
 			default: false,

--- a/src/DashboardWidgetItem.vue
+++ b/src/DashboardWidgetItem.vue
@@ -159,8 +159,9 @@ export default {
 
 <template>
 	<div @mouseover="hovered = true" @mouseleave="hovered = false">
-		<a :href="targetUrl"
-			target="_blank"
+		<component :is="targetUrl ? 'a' : 'div'"
+			:href="targetUrl"
+			:target="targetUrl ? '_blank' : undefined"
 			:class="{ 'item-list__entry': true, 'item-list__entry--has-actions-menu': gotMenu }"
 			@click="onLinkClick">
 			<slot name="avatar" :avatarUrl="avatarUrl" :avatarUsername="avatarUsername">
@@ -192,7 +193,7 @@ export default {
 					{{ m.text }}
 				</ActionButton>
 			</Actions>
-		</a>
+		</component>
 	</div>
 </template>
 

--- a/src/DashboardWidgetItem.vue
+++ b/src/DashboardWidgetItem.vue
@@ -29,7 +29,7 @@ It has an optional context menu.
 
 ### All props
 * itemMenu: An object containing context menu entries that will be displayed for each items
-* targetUrl: Yhe item element is a link to this URL
+* targetUrl: The item element is a link to this URL.
 * avatarUrl: Where to get the avatar image. Used if avatarUsername is not defined.
 * avatarUsername: Name to provide to the Avatar. Used if avatarUrl is not defined.
 * overlayIconUrl: Small icon to display on the bottom-right corner of the avatar. Optional.
@@ -203,35 +203,55 @@ import ActionButton from '@nextcloud/vue/dist/Components/ActionButton'
 export default {
 	name: 'DashboardWidgetItem',
 	components: {
-		// Popover
 		Avatar, Actions, ActionButton,
 	},
 
 	props: {
+		/**
+		 * The item element is a link to this URL (optional)
+		 */
 		targetUrl: {
 			type: String,
-			default: '',
+			default: undefined,
 		},
+		/**
+		 * Where to get the avatar image. (optional) Used if avatarUsername is not defined.
+		 */
 		avatarUrl: {
 			type: String,
-			default: '',
+			default: undefined,
 		},
+		/**
+		 * Name to provide to the Avatar. (optional) Used if avatarUrl is not defined.
+		 */
 		avatarUsername: {
 			type: String,
-			default: '',
+			default: undefined,
 		},
+		/**
+		 * Small icon to display on the bottom-right corner of the avatar (optional)
+		 */
 		overlayIconUrl: {
 			type: String,
-			default: '',
+			default: undefined,
 		},
+		/**
+		 * Item main text (mandatory)
+		 */
 		mainText: {
 			type: String,
 			required: true,
 		},
+		/**
+		 * Item subline text (optional)
+		 */
 		subText: {
 			type: String,
 			default: '',
 		},
+		/**
+		 * An object containing context menu entries that will be displayed for each items (optional)
+		 */
 		itemMenu: {
 			type: Object,
 			default: () => { return {} },

--- a/src/DashboardWidgetItem.vue
+++ b/src/DashboardWidgetItem.vue
@@ -23,23 +23,19 @@
 This component displays a dashboard widget item. It is used by default by the DashboardWidget component.
 You can also use it wherever you want.
 
-It displays the item given as a prop with optional:
-* context menu
+It has an optional context menu.
 
 ## Usage
 
-### Item
-The item object passed as a prop must respect this structure:
-```js static
-const item = {
-	targetUrl: 'https://target.org', // the item element is a link to this URL
-	avatarUrl: 'https://avatar.url/img.png', // used if avatarUsername is not defined
-	avatarUsername: 'Robert', // used if avatarUrl is not defined
-	overlayIconUrl: generateUrl('/svg/core/actions/sound?color=' + this.themingColor), // optional, small icon to display on the bottom-right corner of the avatar
-	mainText: 'First item text',
-	subText: 'First item subtext',
-}
-```
+
+### All props
+* itemMenu: An object containing context menu entries that will be displayed for each items
+* targetUrl: Yhe item element is a link to this URL
+* avatarUrl: Where to get the avatar image. Used if avatarUsername is not defined.
+* avatarUsername: Name to provide to the Avatar. Used if avatarUrl is not defined.
+* overlayIconUrl: Small icon to display on the bottom-right corner of the avatar. Optional.
+* mainText
+* subText
 
 ### Context menu
 You can optionally pass an object in the "itemMenu" prop to define a context
@@ -61,28 +57,28 @@ const itemMenu = {
 }
 ```
 
-### All props
-* itemMenu: An object containing context menu entries that will be displayed for each items
-* item: An object containing the item itself (specific structure must be respected)
-
 ### Events
 * for each menu item, an event named like its key is emitted with the item as a parameter
 
 ## Simplest example
 ```vue
 <template>
-	<DashboardWidgetItem :item="item" />
+	<DashboardWidgetItem
+		:targetUrl="targetUrl"
+		:avatarUrl="avatarUrl"
+		:overlayIconUrl="overlayIconUrl"
+		:mainText="mainText"
+		:subText="subText" />
 </template>
 
 <script>
-import DashboardWidgetItem from '../components/DashboardWidgetItem'
-const myItem = {
-	targetUrl: 'https://target.org',
-	avatarUrl: 'https://avatar.url/img.png',
-	overlayIconUrl: generateUrl('/svg/core/actions/sound?color=' + this.themingColor),
-	mainText: 'I am an item',
-	subText: 'and i can talk',
-}
+import { DashboardWidgetItem } from '@nextcloud/vue-dashboard'
+
+const targetUrl = 'https://target.org'
+const avatarUrl = 'https://avatar.url/img.png'
+const overlayIconUrl = generateUrl('/svg/core/actions/sound?color=' + this.themingColor)
+const mainText = 'I am an item'
+const subText = 'and i can talk'
 
 export default {
 	name: 'MyRootComponentOrWhatever',
@@ -92,7 +88,11 @@ export default {
 	},
 	data() {
 		return {
-			item: myItem
+			targetUrl,
+			avatarUrl,
+			overlayIconUrl,
+			mainText,
+			subText,
 		}
 	},
 }
@@ -103,22 +103,25 @@ export default {
 
 ```vue
 <template>
-	<DashboardWidgetItem :item="item"
+	<DashboardWidgetItem
+		:targetUrl="targetUrl"
+		:avatarUrl="avatarUrl"
+		:overlayIconUrl="overlayIconUrl"
+		:mainText="mainText"
+		:subText="subText"
 		:itemMenu="itemMenu"
 		@hide="onHide"
-		@markDone="onMarkDone"
-		/>
+		@markDone="onMarkDone" />
 </template>
 
 <script>
-import DashboardWidgetItem from '../components/DashboardWidgetItem'
-const myItem = {
-	targetUrl: 'https://target.org',
-	avatarUrl: 'https://avatar.url/img.png',
-	overlayIconUrl: generateUrl('/svg/core/actions/sound?color=' + this.themingColor),
-	mainText: 'I am an item',
-	subText: 'and I can talk',
-}
+import { DashboardWidgetItem } from '@nextcloud/vue-dashboard'
+
+const targetUrl = 'https://target.org'
+const avatarUrl = 'https://avatar.url/img.png'
+const overlayIconUrl = generateUrl('/svg/core/actions/sound?color=' + this.themingColor)
+const mainText = 'I am an item'
+const subText = 'and i can talk'
 
 const myItemMenu = {
 	// triggers an event named "markDone" when clicked
@@ -141,8 +144,12 @@ export default {
 	},
 	data() {
 		return {
-			item: myItem,
-			itemMenu: myItemMenu
+			targetUrl,
+			avatarUrl,
+			overlayIconUrl,
+			mainText,
+			subText,
+			itemMenu: myItemMenu,
 		}
 	},
 }
@@ -153,37 +160,28 @@ export default {
 
 <template>
 	<div @mouseover="hovered = true" @mouseleave="hovered = false">
-		<!--div class="popover-container">
-			<Popover :open="popoverEnabled && hovered" placement="top" class="content-popover" offset="40">
-				<template>
-					<slot name="popover" :item="item">
-						{{ t('core', 'Undefined popover content') }}
-					</slot>
-				</template>
-			</Popover>
-		</div-->
-		<a :href="item.targetUrl"
+		<a :href="targetUrl"
 			target="_blank"
 			:class="{ 'item-list__entry': true, 'item-list__entry--has-actions-menu': gotMenu }"
 			@click="onLinkClick">
-			<slot name="avatar" :item="item">
+			<slot name="avatar" :avatarUrl="avatarUrl" :avatarUsername="avatarUsername">
 				<Avatar
 					class="item-avatar"
 					:size="44"
-					:url="item.avatarUrl"
-					:user="item.avatarUsername"
+					:url="avatarUrl"
+					:user="avatarUsername"
 					:show-user-status="!gotOverlayIcon" />
 			</slot>
-			<img v-if="item.overlayIconUrl"
+			<img v-if="overlayIconUrl"
 				class="item-icon"
 				alt=""
-				:src="item.overlayIconUrl">
+				:src="overlayIconUrl">
 			<div class="item__details">
-				<h3 :title="item.mainText">
-					{{ item.mainText }}
+				<h3 :title="mainText">
+					{{ mainText }}
 				</h3>
-				<p class="message" :title="item.subText">
-					{{ item.subText }}
+				<p class="message" :title="subText">
+					{{ subText }}
 				</p>
 			</div>
 			<Actions v-if="gotMenu" :force-menu="true" menu-align="right">
@@ -211,18 +209,34 @@ export default {
 	},
 
 	props: {
-		item: {
-			type: Object,
+		targetUrl: {
+			type: String,
+			default: '',
+		},
+		avatarUrl: {
+			type: String,
+			default: '',
+		},
+		avatarUsername: {
+			type: String,
+			default: '',
+		},
+		overlayIconUrl: {
+			type: String,
+			default: '',
+		},
+		mainText: {
+			type: String,
 			required: true,
+		},
+		subText: {
+			type: String,
+			default: '',
 		},
 		itemMenu: {
 			type: Object,
 			default: () => { return {} },
 		},
-		/* popoverEnabled: {
-			type: Boolean,
-			default: false,
-		}, */
 	},
 
 	data() {
@@ -232,11 +246,21 @@ export default {
 	},
 
 	computed: {
+		item() {
+			return {
+				targetUrl,
+				avatarUrl,
+				avatarUsername,
+				overlayIconUrl,
+				mainText,
+				subText,
+			}
+		},
 		gotMenu() {
 			return Object.keys(this.itemMenu).length !== 0
 		},
 		gotOverlayIcon() {
-			return this.item.overlayIconUrl && this.item.overlayIconUrl !== ''
+			return this.overlayIconUrl && this.overlayIconUrl !== ''
 		},
 	},
 

--- a/src/DashboardWidgetItem.vue
+++ b/src/DashboardWidgetItem.vue
@@ -27,7 +27,6 @@ It has an optional context menu.
 
 ## Usage
 
-
 ### All props
 * itemMenu: An object containing context menu entries that will be displayed for each items
 * targetUrl: Yhe item element is a link to this URL
@@ -248,12 +247,12 @@ export default {
 	computed: {
 		item() {
 			return {
-				targetUrl,
-				avatarUrl,
-				avatarUsername,
-				overlayIconUrl,
-				mainText,
-				subText,
+				targetUrl: this.targetUrl,
+				avatarUrl: this.avatarUrl,
+				avatarUsername: this.avatarUsername,
+				overlayIconUrl: this.overlayIconUrl,
+				mainText: this.mainText,
+				subText: this.subText,
 			}
 		},
 		gotMenu() {


### PR DESCRIPTION
refs #19

This does not affect how DashboardWidget can be used. It will still forward the item data to DashboardWidgetItem components.

DashboardWidgetItem now has multiple props instead of the 'item' one that was an Object with no constraint.

Embedded doc has been updated.