### PR TITLE
Make sure empty content message is rendered as simple text

### DIFF
--- a/src/DashboardWidget.vue
+++ b/src/DashboardWidget.vue
@@ -262,7 +262,9 @@ export default {
 			<EmptyContent
 				v-if="emptyContentMessage"
 				:icon="emptyContentIcon">
-				{{ emptyContentMessage }}
+				<template #desc>
+					{{ emptyContentMessage }}
+				</template>
 			</EmptyContent>
 		</slot>
 		<a v-else-if="showMore"


### PR DESCRIPTION
Otherwise the new empty-content-message prop still uses an h2 styling.