### PR TITLE
New optional Item prop: id

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,7 @@ It has an optional context menu.
 ## Usage
 
 ### All props
+* id: A unique string/integer identifying the item (optional).
 * itemMenu: An object containing context menu entries that will be displayed for each items
 * targetUrl: The item element is a link to this URL.
 * avatarUrl: Where to get the avatar image. Used if avatarUsername is not defined.
@@ -304,6 +305,7 @@ export default {
 ```vue
 <template>
 	<DashboardWidgetItem
+		:id="myItemId"
 		:targetUrl="targetUrl"
 		:avatarUrl="avatarUrl"
 		:overlayIconUrl="overlayIconUrl"
@@ -316,6 +318,8 @@ export default {
 
 <script>
 import { DashboardWidgetItem } from '@nextcloud/vue-dashboard'
+
+const myItemId = '123abc'
 const targetUrl = 'https://target.org'
 const avatarUrl = 'https://avatar.url/img.png'
 const overlayIconUrl = generateUrl('/svg/core/actions/sound?color=' + this.themingColor)
@@ -341,6 +345,7 @@ export default {
 	},
 	data() {
 		return {
+			myItemId,
 			targetUrl,
 			avatarUrl,
 			overlayIconUrl,

--- a/src/DashboardWidget.vue
+++ b/src/DashboardWidget.vue
@@ -236,6 +236,7 @@ export default {
 			<li v-for="item in displayedItems" :key="item.id">
 				<slot name="default" :item="item">
 					<DashboardWidgetItem
+						:id="item.id"
 						:target-url="item.targetUrl"
 						:avatar-url="item.avatarUrl"
 						:avatar-username="item.avatarUsername"

--- a/src/DashboardWidgetItem.vue
+++ b/src/DashboardWidgetItem.vue
@@ -28,6 +28,7 @@ It has an optional context menu.
 ## Usage
 
 ### All props
+* id: A unique string/integer identifying the item (optional).
 * itemMenu: An object containing context menu entries that will be displayed for each items
 * targetUrl: The item element is a link to this URL.
 * avatarUrl: Where to get the avatar image. Used if avatarUsername is not defined.
@@ -103,6 +104,7 @@ export default {
 ```vue
 <template>
 	<DashboardWidgetItem
+		:id="myItemId"
 		:targetUrl="targetUrl"
 		:avatarUrl="avatarUrl"
 		:overlayIconUrl="overlayIconUrl"
@@ -116,6 +118,7 @@ export default {
 <script>
 import { DashboardWidgetItem } from '@nextcloud/vue-dashboard'
 
+const myItemId = '123abc'
 const targetUrl = 'https://target.org'
 const avatarUrl = 'https://avatar.url/img.png'
 const overlayIconUrl = generateUrl('/svg/core/actions/sound?color=' + this.themingColor)
@@ -143,6 +146,7 @@ export default {
 	},
 	data() {
 		return {
+			myItemId,
 			targetUrl,
 			avatarUrl,
 			overlayIconUrl,
@@ -209,6 +213,13 @@ export default {
 
 	props: {
 		/**
+		 * The item id (optional)
+		 */
+		id: {
+			type: [String, Number],
+			default: undefined,
+		},
+		/**
 		 * The item element is a link to this URL (optional)
 		 */
 		targetUrl: {
@@ -268,6 +279,7 @@ export default {
 	computed: {
 		item() {
 			return {
+				id: this.id,
 				targetUrl: this.targetUrl,
 				avatarUrl: this.avatarUrl,
 				avatarUsername: this.avatarUsername,


### PR DESCRIPTION
This prop is usefull when using item menu actions. The item data is passed to the callback. The id was missing there. It can be used to easily match the parent component data when receiving a menu action event.