### PR TITLE
New 'avatarIsNoUser' item field passed to avatar as 'isNoUser'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Change Log
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/)
+and this project adheres to [Semantic Versioning](http://semver.org/).
+
+## 1.1.0 – 2020-11-13
+### Changed
+- new optional field in widget item data: avatarIsNoUser

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,6 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## 1.1.0 – 2020-11-13
+## 1.1.0 – unreleased
 ### Changed
 - new optional field in widget item data: avatarIsNoUser

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ const itemList = [
 		targetUrl: 'https://target.org', // the item element is a link to this URL
 		avatarUrl: 'https://avatar.url/img.png', // used if avatarUsername is not defined
 		avatarUsername: 'Robert', // used if avatarUrl is not defined
+		avatarIsNoUser: true, // passed to the Avatar component in WidgetItem component
 		overlayIconUrl: generateUrl('/svg/core/actions/sound?color=' + this.themingColor), // optional, small icon to display on the bottom-right corner of the avatar
 		mainText: 'First item text',
 		subText: 'First item subtext',
@@ -142,8 +143,8 @@ export default {
 ```vue
 <template>
 	<DashboardWidget :items="items"
-		:showMoreUrl="'https://nextcloud.com'"
-		:itemMenu="itemMenu"
+		:show-more-url="'https://nextcloud.com'"
+		:item-menu="itemMenu"
 		@hide="onHide"
 		@markDone="onMarkDone"
 		:loading="state === 'loading'">
@@ -162,6 +163,7 @@ const myItems = [
 		targetUrl: 'https://target.org',
 		avatarUrl: 'https://avatar.url/img.png',
 		avatarUsername: 'Robert',
+		avatarIsNoUser: true,
 		overlayIconUrl: generateUrl('/svg/core/actions/sound?color=' + this.themingColor),
 		mainText: 'First item text',
 		subText: 'First item subtext',
@@ -234,6 +236,7 @@ It has an optional context menu.
 * targetUrl: The item element is a link to this URL.
 * avatarUrl: Where to get the avatar image. Used if avatarUsername is not defined.
 * avatarUsername: Name to provide to the Avatar. Used if avatarUrl is not defined.
+* avatarIsNoUser: Is the named a Nextcloud user name? If yes, the user's avatar image will be displayed. This value is passed to the Avatar component in WidgetItem component.
 * overlayIconUrl: Small icon to display on the bottom-right corner of the avatar. Optional.
 * mainText
 * subText
@@ -265,11 +268,11 @@ const itemMenu = {
 ```vue
 <template>
 	<DashboardWidgetItem
-		:targetUrl="targetUrl"
-		:avatarUrl="avatarUrl"
-		:overlayIconUrl="overlayIconUrl"
-		:mainText="mainText"
-		:subText="subText" />
+		:target-url="targetUrl"
+		:avatar-url="avatarUrl"
+		:overlay-icon-url="overlayIconUrl"
+		:main-text="mainText"
+		:sub-text="subText" />
 </template>
 
 <script>
@@ -304,12 +307,14 @@ export default {
 <template>
 	<DashboardWidgetItem
 		:id="myItemId"
-		:targetUrl="targetUrl"
-		:avatarUrl="avatarUrl"
-		:overlayIconUrl="overlayIconUrl"
-		:mainText="mainText"
-		:subText="subText"
-		:itemMenu="itemMenu"
+		:target-url="targetUrl"
+		:avatar-url="avatarUrl"
+		:avatar-username="avatarUsername"
+		:avatar-is-no-user="avatarIsNoUser"
+		:overlay-icon-url="overlayIconUrl"
+		:main-text="mainText"
+		:sub-text="subText"
+		:item-menu="itemMenu"
 		@hide="onHide"
 		@markDone="onMarkDone" />
 </template>
@@ -320,6 +325,8 @@ import { DashboardWidgetItem } from '@nextcloud/vue-dashboard'
 const myItemId = '123abc'
 const targetUrl = 'https://target.org'
 const avatarUrl = 'https://avatar.url/img.png'
+const avatarUsername = 'Johnny'
+const avatarIsNoUser = true
 const overlayIconUrl = generateUrl('/svg/core/actions/sound?color=' + this.themingColor)
 const mainText = 'I am an item'
 const subText = 'and i can talk'

--- a/src/DashboardWidget.vue
+++ b/src/DashboardWidget.vue
@@ -38,6 +38,7 @@
 						:target-url="item.targetUrl"
 						:avatar-url="item.avatarUrl"
 						:avatar-username="item.avatarUsername"
+						:avatar-is-no-user="item.avatarIsNoUser"
 						:overlay-icon-url="item.overlayIconUrl"
 						:main-text="item.mainText"
 						:sub-text="item.subText"

--- a/src/DashboardWidgetItem.vue
+++ b/src/DashboardWidgetItem.vue
@@ -33,6 +33,7 @@
 					:size="44"
 					:url="avatarUrl"
 					:user="avatarUsername"
+					:is-no-user="avatarIsNoUser"
 					:show-user-status="!gotOverlayIcon" />
 			</slot>
 			<img v-if="overlayIconUrl"
@@ -98,6 +99,13 @@ export default {
 		avatarUsername: {
 			type: String,
 			default: undefined,
+		},
+		/**
+		 * Is the avatarUsername not a user's name? (optional, true by default)
+		 */
+		avatarIsNoUser: {
+			type: Boolean,
+			default: true,
 		},
 		/**
 		 * Small icon to display on the bottom-right corner of the avatar (optional)

--- a/src/DashboardWidgetItem.vue
+++ b/src/DashboardWidgetItem.vue
@@ -101,11 +101,11 @@ export default {
 			default: undefined,
 		},
 		/**
-		 * Is the avatarUsername not a user's name? (optional, true by default)
+		 * Is the avatarUsername not a user's name? (optional, false by default)
 		 */
 		avatarIsNoUser: {
 			type: Boolean,
-			default: true,
+			default: false,
 		},
 		/**
 		 * Small icon to display on the bottom-right corner of the avatar (optional)


### PR DESCRIPTION
Hey,

As Avatar's `isNoUser` prop is now false by default, we can't display colored initials for non user stuff in WidgetItem default Avatar template. The `avatarIsNoUser` item data field is passed to a WidgetItem prop which just forwards it to the Avatar component in default Avatar template.