### PR TITLE
Disable Avatar menu if targetUrl set.

### DIFF
--- a/src/DashboardWidgetItem.vue
+++ b/src/DashboardWidgetItem.vue
@@ -34,6 +34,7 @@
 					:url="avatarUrl"
 					:user="avatarUsername"
 					:is-no-user="avatarIsNoUser"
+					:disable-menu="targetUrl"
 					:show-user-status="!gotOverlayIcon" />
 			</slot>
 			<img v-if="overlayIconUrl"


### PR DESCRIPTION
Don't show the avatar-menu if the target url is set, since a click will open the targetUrl, so the menu has no effect.

![grafik](https://user-images.githubusercontent.com/47433654/210666134-e7a6d54d-3d60-4a2b-b9a1-3fdafed535bf.png)
